### PR TITLE
Replace np.float and np.int across 4 files (removed in NumPy 1.24)

### DIFF
--- a/data_loaders/motion_loaders/model_motion_loaders.py
+++ b/data_loaders/motion_loaders/model_motion_loaders.py
@@ -36,7 +36,7 @@ class MMGeneratedDataset(Dataset):
             #                              ], axis=0)
             motion = motion[None, :]
             motions.append(motion)
-        m_lens = np.array(m_lens, dtype=np.int)
+        m_lens = np.array(m_lens, dtype=int)
         motions = np.concatenate(motions, axis=0)
         sort_indx = np.argsort(m_lens)[::-1].copy()
         # print(m_lens)

--- a/data_loaders/scripts/motion_process.py
+++ b/data_loaders/scripts/motion_process.py
@@ -48,14 +48,14 @@ def extract_features(positions, feet_thre, n_raw_offsets, kinematic_chain, face_
         feet_l_z = (positions[1:, fid_l, 2] - positions[:-1, fid_l, 2]) ** 2
         #     feet_l_h = positions[:-1,fid_l,1]
         #     feet_l = (((feet_l_x + feet_l_y + feet_l_z) < velfactor) & (feet_l_h < heightfactor)).astype(np.float)
-        feet_l = ((feet_l_x + feet_l_y + feet_l_z) < velfactor).astype(np.float)
+        feet_l = ((feet_l_x + feet_l_y + feet_l_z) < velfactor).astype(float)
 
         feet_r_x = (positions[1:, fid_r, 0] - positions[:-1, fid_r, 0]) ** 2
         feet_r_y = (positions[1:, fid_r, 1] - positions[:-1, fid_r, 1]) ** 2
         feet_r_z = (positions[1:, fid_r, 2] - positions[:-1, fid_r, 2]) ** 2
         #     feet_r_h = positions[:-1,fid_r,1]
         #     feet_r = (((feet_r_x + feet_r_y + feet_r_z) < velfactor) & (feet_r_h < heightfactor)).astype(np.float)
-        feet_r = (((feet_r_x + feet_r_y + feet_r_z) < velfactor)).astype(np.float)
+        feet_r = (((feet_r_x + feet_r_y + feet_r_z) < velfactor)).astype(float)
         return feet_l, feet_r
 
     #
@@ -234,14 +234,14 @@ def process_file(positions, feet_thre):
         feet_l_z = (positions[1:, fid_l, 2] - positions[:-1, fid_l, 2]) ** 2
         #     feet_l_h = positions[:-1,fid_l,1]
         #     feet_l = (((feet_l_x + feet_l_y + feet_l_z) < velfactor) & (feet_l_h < heightfactor)).astype(np.float)
-        feet_l = ((feet_l_x + feet_l_y + feet_l_z) < velfactor).astype(np.float)
+        feet_l = ((feet_l_x + feet_l_y + feet_l_z) < velfactor).astype(float)
 
         feet_r_x = (positions[1:, fid_r, 0] - positions[:-1, fid_r, 0]) ** 2
         feet_r_y = (positions[1:, fid_r, 1] - positions[:-1, fid_r, 1]) ** 2
         feet_r_z = (positions[1:, fid_r, 2] - positions[:-1, fid_r, 2]) ** 2
         #     feet_r_h = positions[:-1,fid_r,1]
         #     feet_r = (((feet_r_x + feet_r_y + feet_r_z) < velfactor) & (feet_r_h < heightfactor)).astype(np.float)
-        feet_r = (((feet_r_x + feet_r_y + feet_r_z) < velfactor)).astype(np.float)
+        feet_r = (((feet_r_x + feet_r_y + feet_r_z) < velfactor)).astype(float)
         return feet_l, feet_r
     #
     feet_l, feet_r = foot_detect(positions, feet_thre)
@@ -502,14 +502,14 @@ def extract_features(positions, feet_thre, n_raw_offsets, kinematic_chain, face_
         feet_l_z = (positions[1:, fid_l, 2] - positions[:-1, fid_l, 2]) ** 2
         #     feet_l_h = positions[:-1,fid_l,1]
         #     feet_l = (((feet_l_x + feet_l_y + feet_l_z) < velfactor) & (feet_l_h < heightfactor)).astype(np.float)
-        feet_l = ((feet_l_x + feet_l_y + feet_l_z) < velfactor).astype(np.float)
+        feet_l = ((feet_l_x + feet_l_y + feet_l_z) < velfactor).astype(float)
 
         feet_r_x = (positions[1:, fid_r, 0] - positions[:-1, fid_r, 0]) ** 2
         feet_r_y = (positions[1:, fid_r, 1] - positions[:-1, fid_r, 1]) ** 2
         feet_r_z = (positions[1:, fid_r, 2] - positions[:-1, fid_r, 2]) ** 2
         #     feet_r_h = positions[:-1,fid_r,1]
         #     feet_r = (((feet_r_x + feet_r_y + feet_r_z) < velfactor) & (feet_r_h < heightfactor)).astype(np.float)
-        feet_r = (((feet_r_x + feet_r_y + feet_r_z) < velfactor)).astype(np.float)
+        feet_r = (((feet_r_x + feet_r_y + feet_r_z) < velfactor)).astype(float)
         return feet_l, feet_r
 
     #

--- a/diffusion/resample.py
+++ b/diffusion/resample.py
@@ -129,7 +129,7 @@ class LossSecondMomentResampler(LossAwareSampler):
         self._loss_history = np.zeros(
             [diffusion.num_timesteps, history_per_term], dtype=np.float64
         )
-        self._loss_counts = np.zeros([diffusion.num_timesteps], dtype=np.int)
+        self._loss_counts = np.zeros([diffusion.num_timesteps], dtype=int)
 
     def weights(self):
         if not self._warmed_up():

--- a/utils/common/quaternion.py
+++ b/utils/common/quaternion.py
@@ -10,7 +10,7 @@ import numpy as np
 
 _EPS4 = np.finfo(float).eps * 4.0
 
-_FLOAT_EPS = np.finfo(np.float).eps
+_FLOAT_EPS = np.finfo(float).eps
 
 # PyTorch-backed implementations
 def qinv(q):


### PR DESCRIPTION
Thanks for putting this code out — I've been reading through it.

On a current environment (Python 3.12, NumPy 2.x) it uses a few names that NumPy and the stdlib have since removed. These raise rather than warn, so execution stops at the first one reached.

### What breaks

| Location | Symbol | Removed in |
|---|---|---|
| `diffusion/resample.py:132` | `np.int` | NumPy 1.24 |
| `utils/common/quaternion.py:13` | `np.float` | NumPy 1.24 |
| `data_loaders/motion_loaders/model_motion_loaders.py:39` | `np.int` | NumPy 1.24 |
| `data_loaders/scripts/motion_process.py:51` | `np.float` | NumPy 1.24 |
| `data_loaders/scripts/motion_process.py:58` | `np.float` | NumPy 1.24 |
| `data_loaders/scripts/motion_process.py:237` | `np.float` | NumPy 1.24 |
| `data_loaders/scripts/motion_process.py:244` | `np.float` | NumPy 1.24 |
| `data_loaders/scripts/motion_process.py:505` | `np.float` | NumPy 1.24 |
| `data_loaders/scripts/motion_process.py:512` | `np.float` | NumPy 1.24 |

### How I checked

I executed each of these expressions directly against NumPy 2.x to confirm it genuinely raises rather than assuming from the name, and confirmed the replacement returns the same value.

Every file this touches still compiles (`py_compile`).

### What this PR changes

| Old | New | Why it's equivalent |
|---|---|---|
| `np.float` | `float` | `np.float` *was* the builtin `float` |
| `np.int` | `int` | `np.int` *was* the builtin `int`; NumPy's own error text recommends this |

These are exact substitutions — no behavioural or numerical change. Only the lines listed above are touched.

Happy to rework this if you'd rather pin NumPy below 2, or if you'd prefer it split differently.